### PR TITLE
Refactor: Implement streaming for file uploads to reduce memory usage

### DIFF
--- a/src/main/java/com/bts/tailor/controller/VoiceNoteController.java
+++ b/src/main/java/com/bts/tailor/controller/VoiceNoteController.java
@@ -7,6 +7,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.InputStream;
 import java.util.List;
 
 @RestController
@@ -26,9 +27,10 @@ public class VoiceNoteController {
      */
     @PostMapping("/upload")
     public ResponseEntity<String> uploadVoiceNote(@RequestParam("file") MultipartFile file) {
-        try {
-            byte[] fileData = file.getBytes();
-            String fileUrl = service.uploadFile(fileData, file.getOriginalFilename());
+        try (InputStream inputStream = file.getInputStream()) {
+            String originalFileName = file.getOriginalFilename();
+            long contentLength = file.getSize();
+            String fileUrl = service.uploadFile(inputStream, originalFileName, contentLength);
             return ResponseEntity.ok("File uploaded successfully: " + fileUrl);
         } catch (Exception e) {
             return ResponseEntity.internalServerError().body("Error uploading file: " + e.getMessage());

--- a/src/main/java/com/bts/tailor/service/OrderService.java
+++ b/src/main/java/com/bts/tailor/service/OrderService.java
@@ -77,15 +77,16 @@ public class OrderService {
     }
 
 
-    // Method to create an order
-    public Order createOrder(OrderRequest orderRequest, MultipartFile voiceNoteFile) {
-        try {
+import java.io.InputStream;
 
-            byte[] fileData = voiceNoteFile.getBytes();
+// Method to create an order
+    public Order createOrder(OrderRequest orderRequest, MultipartFile voiceNoteFile) {
+        try (InputStream inputStream = voiceNoteFile.getInputStream()) {
             String originalFileName = voiceNoteFile.getOriginalFilename();
+            long contentLength = voiceNoteFile.getSize();
 
             // Upload the voice note and retrieve its URL
-            String voiceNoteUrl = voiceNoteService.uploadFile(fileData, originalFileName);
+            String voiceNoteUrl = voiceNoteService.uploadFile(inputStream, originalFileName, contentLength);
 
             // Build the Measurements object
             Measurements measurements = new Measurements(
@@ -109,7 +110,7 @@ public class OrderService {
             // Save the order to the database
             return orderRepository.save(order);
         } catch (Exception e) {
-            throw new RuntimeException(e);
+            throw new RuntimeException("Failed to create order: " + e.getMessage(), e);
         }
     }
 

--- a/src/main/java/com/bts/tailor/service/VoiceNoteService.java
+++ b/src/main/java/com/bts/tailor/service/VoiceNoteService.java
@@ -7,6 +7,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.http.*;
+import org.springframework.core.io.InputStreamResource;
+import java.io.InputStream;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
@@ -30,7 +32,7 @@ public class VoiceNoteService {
     }
 
     // Upload file to Supabase Storage
-    public String uploadFile(byte[] fileData, String originalFileName) {
+    public String uploadFile(InputStream inputStream, String originalFileName, long contentLength) {
         String uniqueFileName = UUID.randomUUID() + "-" + originalFileName;
         String uploadUrl = String.format("%s/storage/v1/object/%s/%s", supabaseUrl, bucketName, uniqueFileName);
 
@@ -39,8 +41,9 @@ public class VoiceNoteService {
         headers.set("Authorization", "Bearer " + supabaseKey);
         headers.set("apikey", supabaseKey);
         headers.setContentType(MediaType.APPLICATION_OCTET_STREAM);
+        headers.setContentLength(contentLength);
 
-        HttpEntity<byte[]> requestEntity = new HttpEntity<>(fileData, headers);
+        HttpEntity<InputStreamResource> requestEntity = new HttpEntity<>(new InputStreamResource(inputStream), headers);
         ResponseEntity<String> response = restTemplate.exchange(uploadUrl, HttpMethod.PUT, requestEntity, String.class);
 
         if (response.getStatusCode().is2xxSuccessful()) {


### PR DESCRIPTION
Previously, file uploads (both via order creation and direct voice note upload) involved reading the entire MultipartFile into a byte array in memory. This could lead to high memory consumption and potential OutOfMemoryErrors, especially with large files or concurrent uploads.

This commit refactors the file handling mechanism:

1.  `VoiceNoteService.uploadFile` now accepts an `InputStream` and `contentLength` instead of a `byte[]`. It uses `InputStreamResource` with `RestTemplate` to stream the file content to Supabase storage.

2.  `OrderService.createOrder` has been updated to obtain an `InputStream` and `contentLength` from the `MultipartFile` and pass them to the refactored `VoiceNoteService`. It uses a try-with-resources statement to ensure the InputStream is closed.

3.  `VoiceNoteController.uploadVoiceNote` (which provides a direct file upload endpoint) has also been updated similarly to `OrderService` to use `InputStream` and try-with-resources.

These changes ensure that files are streamed directly to the storage service (Supabase) without being fully loaded into application memory, significantly improving memory efficiency and resilience against out-of-memory errors during file uploads.